### PR TITLE
chore: Remove unecessary dependencies

### DIFF
--- a/lib/utils/rem.ts
+++ b/lib/utils/rem.ts
@@ -1,4 +1,33 @@
-import { RFValue } from "react-native-responsive-fontsize";
+import { Dimensions, StatusBar, Platform } from 'react-native';
+
+const dimensions = Dimensions.get('window');
+
+function isIPhoneX() {
+  return (
+    Platform.OS === 'ios' &&
+    !Platform.isPad &&
+    !Platform.isTVOS &&
+    ((dimensions.height === 780 || dimensions.width === 780)
+      || (dimensions.height === 812 || dimensions.width === 812)
+      || (dimensions.height === 844 || dimensions.width === 844)
+      || (dimensions.height === 896 || dimensions.width === 896)
+      || (dimensions.height === 926 || dimensions.width === 926))
+  );
+}
+
+const standardLength = Math.max(dimensions.width, dimensions.height);
+const offset =
+  dimensions.width > dimensions.height ? 0 : Platform.OS === "ios" ? 78 : StatusBar.currentHeight as number;
+
+const deviceHeight =
+  isIPhoneX() || Platform.OS === "android"
+    ? standardLength - offset
+    : standardLength;
+
+function responsiveFontSize(fontSize: number, standardScreenHeight = 680) {
+  const heightPercent = (fontSize * deviceHeight) / standardScreenHeight;
+  return Math.round(heightPercent);
+}
 
 type RemParams = {
   size: number;
@@ -13,5 +42,5 @@ export function rem({
   shouldScale = false,
   fontScaleFactor = 1,
 }: RemParams) {
-  return RFValue(size * baseFontSize) * (shouldScale ? fontScaleFactor : 1) 
+  return responsiveFontSize(size * baseFontSize) * (shouldScale ? fontScaleFactor : 1) 
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.1.tar.gz",
-    "react-native-responsive-fontsize": "^0.5.0",
     "react-native-safe-area-context": "3.1.9",
     "react-native-web": "~0.13.12",
     "styled-components": "^5.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5371,18 +5371,6 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-native-iphone-x-helper@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
-  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
-
-react-native-responsive-fontsize@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-responsive-fontsize/-/react-native-responsive-fontsize-0.5.0.tgz#76940797bebdce146ead84beb4418fb14309c980"
-  integrity sha512-yeZ6ub1QhBmK5cwkj2+SzrcNOE5OXS9ritLDF3X7x7X6aRbOGXAOKQ7VoLnctOeLxJla98n+Fcs5+0rtvYwlBA==
-  dependencies:
-    react-native-iphone-x-helper "^1.3.1"
-
 react-native-safe-area-context@3.1.9:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.9.tgz#48864ea976b0fa57142a2cc523e1fd3314e7247e"


### PR DESCRIPTION
Congratulations on the work! :clap: 
This was really good. :rocket: 

I noticed that the [react-native-responsive-fontsize](https://github.com/heyman333/react-native-responsive-fontSize) was being used, that lib still used [react-native-iphone-x-helper](https://github.com/ptelad/react-native-iphone-x-helper). So I removed these deps from the project, so we won't be dependent on a third-party library.